### PR TITLE
Error while unpacking static array

### DIFF
--- a/src/msgpack.d
+++ b/src/msgpack.d
@@ -1918,7 +1918,10 @@ struct Unpacker
             }
 
             canRead(length, offset + Offset);
-            array = cast(T)read(length);
+            static if (isStaticArray!T) {
+        		array = (cast(U[])read(length))[0 .. T.length];
+			} else
+                array = cast(T)read(length);
 
             static if (isDynamicArray!T)
                 hasRaw_ = true;


### PR DESCRIPTION
The following fails to compile:

```
import msgpack;

void main()
{
    ubyte[] data;
    auto unpacker = Unpacker(data);

    char[32] uuid;
    unpacker.unpack(uuid);
}
```

The error is:

```
msgpack.d(1921): Error: e2ir: cannot cast this.read(length) of type ubyte[] to type char[32LU]
```

The attached commit resolves this error, by casting then slicing. I'm unsure of the preferred practice for converting from dynamic to static arrays, but this seems to work just fine.
