### PR TITLE
remove redundant DFLAGS from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,5 @@
     "copyright":   "Copyright (c) 2010- Masahiro Nakagawa",
 
     "importPaths": ["src"],
-    "dflags-dmd":  ["-w", "-d", "-property"],
     "targetType":  "library"
 }


### PR DESCRIPTION
- dub enables warnings by default
- deprecation warnings are dmd default
- property is deprecated and may break building
  other dub packages
