### PR TITLE
Pack empty arrays as zero-length arrays

### DIFF
--- a/example/simple.d
+++ b/example/simple.d
@@ -14,7 +14,9 @@ void main()
 {
     auto packer = packer(appender!(ubyte[])());
 
-    packer.packArray(null, true, "Hi!", -1, [1, 2]);
+    int[] emptyArray;
+    int[int] emptyMap;
+    packer.packArray(null, true, "Hi!", -1, [1, 2], emptyArray, emptyMap);
 
     auto unpacker = StreamingUnpacker(packer.stream.data);
 

--- a/src/msgpack.d
+++ b/src/msgpack.d
@@ -698,9 +698,6 @@ struct PackerImpl(Stream) if (isOutputRange!(Stream, ubyte) && isOutputRange!(St
             }
         }
 
-        if (array.empty)
-            return packNil();
-
         // Raw bytes
         static if (isByte!(U) || isSomeChar!(U)) {
             ubyte[] raw = cast(ubyte[])array;
@@ -720,9 +717,6 @@ struct PackerImpl(Stream) if (isOutputRange!(Stream, ubyte) && isOutputRange!(St
     /// ditto
     ref PackerImpl pack(T)(in T array) if (isAssociativeArray!T)
     {
-        if (array is null)
-            return packNil();
-
         beginMap(array.length);
         foreach (key, value; array) {
             pack(key);


### PR DESCRIPTION
It is point at issue, but it seems like it is better in terms of compatibility with other languages. For example, msgpack-c provides default adapters for vectors and strings that throw an exception in case of nil value deserialization. It is ok to send c++ empty std::vectors, std::strings, std::vectors of std::strings, etc, packed by default to the dlang application and get dlang empty strings, arrays[], etc, but not the other way around. That's why communication between dlang-app and cpp-app via msgpack is complicated. Also python implementation of msgpack produces zero-length arrays. In addition, zero-length arrays are serialized into one byte as well as nil value.