### PR TITLE
Implement EXT types

### DIFF
--- a/src/msgpack.d
+++ b/src/msgpack.d
@@ -1037,7 +1037,8 @@ struct PackerImpl(Stream) if (isOutputRange!(Stream, ubyte) && isOutputRange!(St
             const temp = convertEndianTo!32(data.length);
             *cast(uint*)&store_[Offset] = temp;
             typeByte = 5;
-        }
+        } else
+            throw new MessagePackException("Data too large to pack as EXT");
 
         store_[typeByte] = type;
         stream_.put(store_[0..typeByte+1]);

--- a/src/msgpack.d
+++ b/src/msgpack.d
@@ -2665,7 +2665,8 @@ struct Unpacker
 
 
     /// ditto
-    ref Unpacker unpack(T)(ref T object) if (is(Unqual!T == struct))
+    ref Unpacker unpack(T)(ref T object) if (is(Unqual!T == struct) &&
+                                             !is(Unqual!T == ExtValue))
     {
         static if (hasMember!(T, "fromMsgpack"))
         {
@@ -3295,14 +3296,6 @@ unittest
 
 // Static resolution routines for Stream deserializer
 
-/**
- * $(D ExtValue) is a $(D MessagePack) Extended value representation
- */
-struct ExtValue
-{
-    byte type;    /// An integer 0-127 with application-defined meaning
-    ubyte[] data; /// The raw bytes
-}
 
 /**
  * $(D Value) is a $(D MessagePack) value representation
@@ -4080,6 +4073,18 @@ unittest
      * static struct NonMessagePackable {}
      * auto nonMessagePackable = value.as!(NonMessagePackable);
      */
+}
+
+
+/**
+ * $(D ExtValue) is a $(D MessagePack) Extended value representation.
+ * The application is responsible for correctly interpreting $(D data) according
+ *  to the type described by $(D type).
+ */
+struct ExtValue
+{
+    byte type;    /// An integer 0-127 with application-defined meaning
+    ubyte[] data; /// The raw bytes
 }
 
 


### PR DESCRIPTION
This MR implements the EXT family of types as described by v5 of the MessagePack spec (https://github.com/msgpack/msgpack/blob/master/spec.md#ext-format-family).

Notes:
* Added `ExtValue` struct to represent the (type, data) tuple.
* Added `ext` to the Value.Via union, added appropriate `as!`, `opEquals`, `getHash`
* Implemented `Packer.pack!ExtValue` and `Packer.packExt(type, data)`
* Implemented `Unpacker.unpack!ExtValue`
* Added `Unpacker.unpackExt(type, data)` which takes both parameters by ref and checks given type against type in stream, given data length against length in stream.
* I've added unittests in the appropriate locations for each new method.

The commits are fairly atomic so you may find it easier to review them one at a time.