### PR TITLE
note that it needs at least 0.15.2 beta2 for LDC

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,7 @@ Note that `Unpacker` will raise an exception if a loss of precision occurs.
 ## Current Limitations
 
 * No circular references support
+* if you use the LDC compiler you need at least version 0.15.2 beta2
 
 # Install
 


### PR DESCRIPTION
make a note that msgpack-d is not compatible with ldc prior to 0.15.2 beta2.

for 0.15.1 you will see a failing test.
this is unrelated to the removal of the ldc workaround from yesterday