### PR TITLE
Fixed cast issues for 16bit/32bit integers...

### DIFF
--- a/src/msgpack.d
+++ b/src/msgpack.d
@@ -5031,10 +5031,10 @@ struct StreamingUnpacker
                     callbackUInt(obj, buffer_[base]);
                     goto Lpush;
                 case State.UINT16:
-                    callbackUInt(obj, load16To!ulong(buffer_[base..base + trail]));
+                    callbackUInt(obj, load16To!ushort(buffer_[base..base + trail]));
                     goto Lpush;
                 case State.UINT32:
-                    callbackUInt(obj, load32To!ulong(buffer_[base..base + trail]));
+                    callbackUInt(obj, load32To!uint(buffer_[base..base + trail]));
                     goto Lpush;
                 case State.UINT64:
                     callbackUInt(obj, load64To!ulong(buffer_[base..base + trail]));
@@ -5043,10 +5043,10 @@ struct StreamingUnpacker
                     callbackInt(obj, cast(byte)buffer_[base]);
                     goto Lpush;
                 case State.INT16:
-                    callbackInt(obj, load16To!long(buffer_[base..base + trail]));
+                    callbackInt(obj, load16To!short(buffer_[base..base + trail]));
                     goto Lpush;
                 case State.INT32:
-                    callbackInt(obj, load32To!long(buffer_[base..base + trail]));
+                    callbackInt(obj, load32To!int(buffer_[base..base + trail]));
                     goto Lpush;
                 case State.INT64:
                     callbackInt(obj, load64To!long(buffer_[base..base + trail]));


### PR DESCRIPTION
Hi,
Using msgpack-d with negative 16 bit integers via the callback mechanism yielded issues. I hope this is the correct fix for it (it certainly works for me!)
(I did the same for the uints just to be consistent, but is not strictly necessary).