### PR TITLE
Fix memory allocation bug when bytes are corrupted

### DIFF
--- a/src/msgpack/package.d
+++ b/src/msgpack/package.d
@@ -226,6 +226,8 @@ unittest
 }
 
 unittest {
+    import std.exception: assertThrown;
+
     struct Version {
         int major= -1;
         int minor = -1;
@@ -266,7 +268,7 @@ unittest {
                      100,  35, 168];
 
     // should not throw OutOfMemoryError
-    unpack!PubSubMessage(bytes);
+    assertThrown!MessagePackException(unpack!PubSubMessage(bytes));
 }
 
 

--- a/src/msgpack/package.d
+++ b/src/msgpack/package.d
@@ -206,7 +206,7 @@ unittest
 unittest
 {
     import std.typetuple;
-    
+
     // char types
     foreach (Type; TypeTuple!(char, wchar, dchar)) {
         foreach (i; [Type.init, Type.min, Type.max, cast(Type)'j']) {
@@ -223,6 +223,50 @@ unittest
     // ext type
     auto result = unpack(pack(ExtValue(7, [1,2,3,4])));
     assert(result == ExtValue(7, [1,2,3,4]));
+}
+
+unittest {
+    struct Version {
+        int major= -1;
+        int minor = -1;
+    }
+
+    struct SubscriptionTopic {
+        string[] topicComponents;
+    }
+
+    struct SubscriptionSender
+    {
+        string hostName;
+        string biosName;
+    }
+
+    struct PubSubMessage {
+
+        enum Type {
+            publication,
+            subscribe,
+            unsubscribe,
+        }
+
+        Version version_;
+        Type type;
+        SubscriptionSender sender;
+        SubscriptionTopic topic;
+        string value;
+    }
+
+    ubyte[] bytes = [149, 146, 255, 255,   0, 146, 164, 104,
+                     111, 115, 116, 164,  98, 105, 111, 115,
+                     145, 221, 171, 105, 110, 116, 101, 114,
+                     101, 115, 116, 105, 110, 103, 165, 116,
+                     111, 112, 105,  99, 167, 112,  97, 121,
+                     108, 111,  97, 100, 158, 142, 210,  31,
+                     127,  81, 149, 125, 183, 108,  86,  17,
+                     100,  35, 168];
+
+    // should not throw OutOfMemoryError
+    unpack!PubSubMessage(bytes);
 }
 
 

--- a/src/msgpack/unpacker.d
+++ b/src/msgpack/unpacker.d
@@ -510,8 +510,19 @@ struct Unpacker
         }
 
         // Raw bytes
-        static if (isByte!U || isSomeChar!U) {
+        static if (isByte!U || isSomeChar!U)
             auto length = beginRaw();
+        else
+            auto length = beginArray();
+
+        if(length > buffer_.length) {
+            import std.conv: text;
+            throw new MessagePackException(text("Invalid array size in byte stream: Length (", length,
+                                                ") is larger than internal buffer size (", buffer_.length, ")"));
+        }
+
+        // Raw bytes
+        static if (isByte!U || isSomeChar!U) {
             auto offset = calculateSize!(true)(length);
             if (length == 0)
                 return this;
@@ -531,7 +542,6 @@ struct Unpacker
             static if (isDynamicArray!T)
                 hasRaw_ = true;
         } else {
-            auto length = beginArray();
             if (length == 0)
                 return this;
 
@@ -1415,7 +1425,7 @@ unittest
             packer.stream.clear();
             packer.pack(c1);
             auto unpacker2 = Unpacker(packer.stream.data);
-            unpacker2.unpack(c3);            
+            unpacker2.unpack(c3);
             //unpack(pack(c1), c3);
             assert(c3.i == c1.i);
         }


### PR DESCRIPTION
I found this via fuzz testing.

If the serialised bytes are corrupted somehow, it can cause msgpack-d to throw an `OutOfMemoryError`. This patch fixes that.