### PR TITLE
 Fix integral promotion deprecation (#98)

### DIFF
--- a/src/msgpack/unpacker.d
+++ b/src/msgpack/unpacker.d
@@ -196,7 +196,7 @@ struct Unpacker
         if (0x00 <= header && header <= 0x7f) {
             value = cast(T)header;
         } else if (0xe0 <= header && header <= 0xff) {
-            value = -(cast(T)-header);
+            value = cast(T)cast(byte)header;
         } else {
             switch (header) {
             case Format.UINT8:


### PR DESCRIPTION
Casting to byte to get negative sign then cast it to the target type T.