### PR TITLE
remove dip flags for library build

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -6,7 +6,14 @@
     "license":     "Boost Software License, Version 1.0",
     "copyright":   "Copyright (c) 2010- Masahiro Nakagawa",
 
-    "importPaths": ["src"],
-    "targetType":  "library",
-    "dflags": ["-dip25", "-dip1000"]
+    "configurations": [
+        {
+            "name": "default",
+            "targetType": "library"
+        },
+        {
+            "name": "unittest",
+            "dflags": ["-dip25", "-dip1000"]
+        }
+    ]
 }


### PR DESCRIPTION
because they are infectious and mean anything that depends on this library is forced to use them.