### PR TITLE
`pragma(lib, "WS2_32")` only on Windows

### DIFF
--- a/src/msgpack/package.d
+++ b/src/msgpack/package.d
@@ -42,7 +42,9 @@ import msgpack.streaming_unpacker;
 import msgpack.register;
 import msgpack.value;
 
-pragma(lib, "WS2_32");
+version(Windows) {
+    pragma(lib, "WS2_32");
+}
 
 @trusted:
 


### PR DESCRIPTION
This fixes link errors I got with ldc2 on Linux that look like
```
/usr/bin/ld.gold: error: cannot find -lWS2_32
```