### PR TITLE
Update version number in meson.build to 1.0.3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
  project('msgpack-d', 'd',
     meson_version: '>=0.47',
     license: 'BSL-1.0',
-    version: '1.0.0'
+    version: '1.0.3'
 )
 
 project_soversion = '1'


### PR DESCRIPTION
The version number was behind in meson.build. This updates it, so projects built using Meson which use this library can transparently switch between this library from dub or subproject.