### PR TITLE
Correct prototype of _d_newclass

### DIFF
--- a/src/msgpack/unpacker.d
+++ b/src/msgpack/unpacker.d
@@ -15,7 +15,7 @@ import std.container;
 
 
 // for unpack without calling constructor
-private extern(C) Object _d_newclass(in ClassInfo);
+private extern(C) Object _d_newclass(const ClassInfo);
 
 
 /**


### PR DESCRIPTION
It's been recently changed from 'in' to 'const',
however since it's extern(C), it doesn't matter to us.